### PR TITLE
Isolated sonification to restore buildability on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,6 +55,9 @@ option(ENABLE_LLVM_COVERAGE "Enable coverage analysis" OFF)
 # Enable dSYM hack (only relevant for macOS builds)
 option(ENSURE_DSYM "Ensure that .dSYM files are generated" OFF)
 
+# Enable Sonification
+option(CANDY_ENABLE_SONIFICATION "Enable the Glucose sonification" OFF)
+
 
 ### Using ctest as a test
 
@@ -70,8 +73,9 @@ set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} -DNDEBUG -Wall -flto -fn
 
 ### Additional Preprocessor Defintions
 
-add_definitions(-DSONIFICATION)
-
+if(CANDY_ENABLE_SONIFICATION)
+  add_definitions(-DSONIFICATION)
+endif()
 
 ### Find libraries
 
@@ -97,12 +101,17 @@ endfunction()
 
 ### Set up include directories
 
-include_directories(${PROJECT_SOURCE_DIR})
+include_directories(${PROJECT_SOURCE_DIR}/src)
 # for refactoring purposes, TODO: use e.g. candy/core/SolverTypes.h instead of core/SolverTypes.h
 include_directories(${PROJECT_SOURCE_DIR}/src/candy)
 
 set(GTEST_INCLUDE_DIRS "${PROJECT_SOURCE_DIR}/lib/googletest/googletest/include" "${PROJECT_SOURCE_DIR}/lib/googletest/googlemock/include")
 
+if(CANDY_ENABLE_SONIFICATION)
+  # ...at least until we build oscpack via the submodule (TODO):
+  include_directories("/usr/local/include")
+  include_directories("/usr/include")
+endif()
 
 ### Add subdirectories (containing CMakeLists with further, directory-specific build instructions)
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,2 +1,3 @@
 add_subdirectory(candy)
 add_subdirectory(sonification)
+

--- a/src/candy/core/Solver.h
+++ b/src/candy/core/Solver.h
@@ -60,7 +60,7 @@
 
 #include "CNFProblem.h"
 
-#include "src/sonification/SolverSonification.h"
+#include "sonification/SolverSonification.h"
 
 namespace Glucose {
 

--- a/src/sonification/CMakeLists.txt
+++ b/src/sonification/CMakeLists.txt
@@ -4,6 +4,7 @@ add_library(sonification
     SolverSonification.cc
     SolverSonification.h)
 
-include_directories("/usr/local/include/oscpack/")
-
-target_link_libraries(sonification oscpack)
+if(CANDY_ENABLE_SONIFICATION)
+  # TODO: use find_package, or warn the user that oscpack needs to be installed
+  target_link_libraries(sonification oscpack)
+endif()

--- a/src/sonification/SolverSonification.cc
+++ b/src/sonification/SolverSonification.cc
@@ -5,7 +5,7 @@
  *      Author: markus
  */
 
-#include <src/sonification/SolverSonification.h>
+#include <sonification/SolverSonification.h>
 
 SolverSonification::SolverSonification()
  : Sonification() {

--- a/src/sonification/SolverSonification.h
+++ b/src/sonification/SolverSonification.h
@@ -8,7 +8,7 @@
 #ifndef SRC_SONIFICATION_SOLVERSONIFICATION_H_
 #define SRC_SONIFICATION_SOLVERSONIFICATION_H_
 
-#include <src/sonification/Sonification.h>
+#include <sonification/Sonification.h>
 
 class SolverSonification: public Sonification {
 public:

--- a/src/sonification/Sonification.cc
+++ b/src/sonification/Sonification.cc
@@ -5,7 +5,7 @@
  *      Author: markus
  */
 
-#include <src/sonification/Sonification.h>
+#include <sonification/Sonification.h>
 
 #ifdef SONIFICATION
 Sonification::Sonification() :

--- a/src/sonification/Sonification.h
+++ b/src/sonification/Sonification.h
@@ -8,8 +8,10 @@
 #ifndef SRC_SONIFICATION_SONIFICATION_H_
 #define SRC_SONIFICATION_SONIFICATION_H_
 
-#include "/usr/local/include/oscpack/osc/OscOutboundPacketStream.h"
-#include "/usr/local/include/oscpack/ip/UdpSocket.h"
+#ifdef SONIFICATION
+#include "oscpack/osc/OscOutboundPacketStream.h"
+#include "oscpack/ip/UdpSocket.h"
+#endif
 
 #define DEFAULT_ADDRESS "127.0.0.1"
 #define DEFAULT_PORT 7000
@@ -18,7 +20,11 @@
 
 class Sonification {
 private:
+#ifdef SONIFICATION
     UdpTransmitSocket transmitSocket;
+#else
+    void* transmitSocket;
+#endif
 
 public:
 	Sonification();


### PR DESCRIPTION
This fix isn't pretty, but the sonification integration prevented me from building the Kingdom. It can now be switched via the CMake parameter -DCANDY_ENABLE_SONIFICATION=[ON|OFF]

(This is untested for CANDY_ENABLE_SONIFICATION=ON.)