### PR TITLE
Moved the position of utils in the libary dependency list

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,7 +181,7 @@ endif()
 
 add_subdirectory(src)
 
-set(CANDY_LIBS utils gates randomsimulation rsil rsar sonification ipasir core simp ${ZLIB_LIBRARIES})
+set(CANDY_LIBS gates randomsimulation rsil rsar sonification ipasir core simp utils ${ZLIB_LIBRARIES})
 
 add_subdirectory(lib)
 add_subdirectory(testsrc)


### PR DESCRIPTION
...so that the symbols do not get optimized away on GNU/Linux.

This should fix #21.
