### PR TITLE
Fixes for win32 compiling and linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -299,7 +299,14 @@ target_link_libraries(candylib ${CANDY_LIBS})
 add_executable(candy src/candy/Main.cc $<TARGET_OBJECTS:frontend>)
 add_executable(cnf2aig src/candy/cnf2aig.cc $<TARGET_OBJECTS:frontend>)
 candy_executable_customizations(candy)
-target_link_libraries(candy candylib)
-target_link_libraries(cnf2aig candylib)
+FIND_LIBRARY (PSAPI Psapi)
+if (PSAPI)
+	target_link_libraries(candy candylib ${PSAPI})
+	target_link_libraries(cnf2aig candylib ${PSAPI})
+ELSE()
+	target_link_libraries(candy candylib)
+	target_link_libraries(cnf2aig candylib)
+ENDIF()
+
 
 

--- a/src/candy/utils/Runtime.cc
+++ b/src/candy/utils/Runtime.cc
@@ -24,10 +24,13 @@
  
  */
 
+#ifdef _WIN32
+#include <Windows.h>
+#endif
+
 namespace Candy { 
 
 #ifdef _WIN32
-#include <Windows.h>
     double get_wall_time() {
         LARGE_INTEGER time,freq;
         if (!QueryPerformanceFrequency(&freq)){


### PR DESCRIPTION
- gcc 6+ will throw an error if std imports are within custom namespace.

- cmake needs to include psapi for win32 systems or GetProcessMemoryInfo will cause linking to fail on windows. 
Cannot use "if(win32)" in cmake in this case because appveyor will fail on that because it claims to be win32 but doesn't supply psapi environmentals. 